### PR TITLE
Add basic Jest test for API root

### DIFF
--- a/api/jest.config.js
+++ b/api/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node'
+};

--- a/api/package.json
+++ b/api/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "node ./bin/www"
+    "start": "node ./bin/www",
+    "test": "jest"
   },
   "dependencies": {
     "body-parser": "^1.19.0",
@@ -18,5 +19,9 @@
     "mongoose-partial-full-search": "^0.0.4",
     "morgan": "~1.9.1",
     "nodemon": "^2.0.4"
+  },
+  "devDependencies": {
+    "jest": "^29.6.2",
+    "supertest": "^6.3.3"
   }
 }

--- a/api/test/root.test.js
+++ b/api/test/root.test.js
@@ -1,0 +1,10 @@
+const request = require('supertest');
+const app = require('../app');
+
+describe('GET /', () => {
+  it('responds with expected text', async () => {
+    const res = await request(app).get('/');
+    expect(res.statusCode).toBe(200);
+    expect(res.text).toBe('Hey! Quit snooping. Go away and mind your own business!');
+  });
+});


### PR DESCRIPTION
## Summary
- install Jest & Supertest for the API server
- configure Jest with `testEnvironment: node`
- create a simple test verifying the root endpoint returns the expected text
- expose `npm test` script

## Testing
- `npm test` *(fails: jest not found)*