### PR TITLE
Remove double JSON parsing from client code

### DIFF
--- a/client/src/components/clients/ClientArchivePage.js
+++ b/client/src/components/clients/ClientArchivePage.js
@@ -14,8 +14,7 @@ function ClientArchivePage() {
     },[])
 
     const clientArchivePageOnLoad = async () => {
-        let archivedClientsJSON = await getArchivedClientsFromDB()
-        let archivedClients = JSON.parse(archivedClientsJSON)
+        let archivedClients = await getArchivedClientsFromDB()
 
         let filteredArchivedClients = archivedClients.filter(item => {
             return item.client_status === 'archived'

--- a/client/src/components/clients/ClientViewPage.js
+++ b/client/src/components/clients/ClientViewPage.js
@@ -12,7 +12,7 @@ function ClientViewPage() {
     
     const clientViewPageOnLoad = async (id) => {
         let clientData = await getClientById(id)
-        setClientViewData(JSON.parse(clientData)[0])
+        setClientViewData(clientData[0])
     }
 
     useEffect(()=>{

--- a/client/src/components/clients/SearchResults.js
+++ b/client/src/components/clients/SearchResults.js
@@ -3,7 +3,7 @@ import ClientContext from '../../context/ClientContext'
 
 function SearchResults(props) {
     const {handleEditClient} = useContext(ClientContext)
-    let searchResult = JSON.parse(props.searchResult)
+    let searchResult = props.searchResult
     console.log(searchResult)
 
     return(

--- a/client/src/components/inspection/InspectionHome.js
+++ b/client/src/components/inspection/InspectionHome.js
@@ -32,9 +32,9 @@ function InspectionHome() {
     },[])
 
     const getInspectionData = async (id) => {
-        let inspectionDataJSON = await getInspectionByIdFromDB(id)
-        if(inspectionDataJSON){
-            setInspectionData(JSON.parse(inspectionDataJSON)[0])
+        let inspectionData = await getInspectionByIdFromDB(id)
+        if(inspectionData){
+            setInspectionData(inspectionData[0])
         }
     }
 

--- a/client/src/components/inspection/NewAccess.js
+++ b/client/src/components/inspection/NewAccess.js
@@ -72,16 +72,16 @@ function NewAccess() {
     const getInspectionDataOnLoad = async (id, accessNum) => {
         console.log(id)
         console.log(accessNum)
-        let inspectionDataJSON = await getInspectionById(id)
+        let inspectionData = await getInspectionById(id)
         var inspectionDataObj;
 
         try {
-            inspectionDataObj = JSON.parse(inspectionDataJSON)[0]
+            inspectionDataObj = inspectionData[0]
             // console.log(inspectionDataObj)
             setInspectionData(inspectionDataObj)
         } catch(err){
             console.log(err)
-        } 
+        }
     }
 
     const preloadFormData = () => {

--- a/client/src/components/report/ReportOverview.js
+++ b/client/src/components/report/ReportOverview.js
@@ -33,11 +33,11 @@ function ReportOverview() {
     const [plusOneYear, setPlusOneYear] = useState(null)
 
     const getInspectionByIdOnLoad = async(id) => {
-        let inspectionDataJSON = await getInspectionById(id)
+        let inspectionData = await getInspectionById(id)
         let inspectionObj;
 
         try{
-            inspectionObj = JSON.parse(inspectionDataJSON)
+            inspectionObj = inspectionData
             console.log(inspectionObj[0])
             setInspectionData(inspectionObj[0])
             console.log(inspectionData)

--- a/client/src/components/worksheet_sections/InspectionAccess.js
+++ b/client/src/components/worksheet_sections/InspectionAccess.js
@@ -19,10 +19,8 @@ function InspectionAccess() {
     const [nextAccessNumber, setNextAccessNumber] = useState(0)
 
     const getInspectionDataOnLoad = async (id) => {
-        let inspectionDataJSON = await getInspectionById(id)
-        let inspectionDataObj;
-        if(inspectionDataJSON){
-            inspectionDataObj = JSON.parse(inspectionDataJSON)
+        let inspectionDataObj = await getInspectionById(id)
+        if(inspectionDataObj){
             setInspectionData(inspectionDataObj[0])
         }
         

--- a/client/src/components/worksheet_sections/InspectionOverview.js
+++ b/client/src/components/worksheet_sections/InspectionOverview.js
@@ -122,10 +122,10 @@ function JobOverview() {
         let searchValue = clientTextRef.current.value
         let searchResults = await searchForClientInDB(encodeURI(searchValue))
 
-        let searchResultObj; 
-        
+        let searchResultObj;
+
         try{
-            searchResultObj = JSON.parse(searchResults)
+            searchResultObj = searchResults
             console.log(searchResultObj)
             setDropdownClients(searchResultObj.map(item => {
                 return({name: (item.organization_name || item.client_name), id: item._id})

--- a/client/src/components/worksheet_sections/Observations.js
+++ b/client/src/components/worksheet_sections/Observations.js
@@ -73,10 +73,10 @@ function Observations() {
 
     const getInspectionData = async (id) => {
         if(id){
-            let inspectionJSON = await getInspectionById(id)
-            console.log(inspectionJSON)
-            return JSON.parse(inspectionJSON)[0]
-            // return JSON.parse(inspectionJSON)
+            let inspectionData = await getInspectionById(id)
+            console.log(inspectionData)
+            return inspectionData[0]
+            // return inspectionData
         }
     }
 

--- a/client/src/pages/Clients.js
+++ b/client/src/pages/Clients.js
@@ -50,11 +50,11 @@ function Clients() {
 
     const getClientsOnLoad = async () => {
         let clientList = await getClientsFromDB()
-        setClientsFromDb(JSON.parse(clientList))
+        setClientsFromDb(clientList)
     }
     const getClientArchiveOnLoad = async () => {
         let clientList = await getArchivedClientsFromDB()
-        setArchivedClientsFromDb(JSON.parse(clientList))
+        setArchivedClientsFromDb(clientList)
     }
     
     useEffect(()=>{

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -14,8 +14,8 @@ function Home() {
         let scheduledInspections = await getScheduledInspectionsFromDB()
         let recentInspections = await getRecentInspectionsFromDB()
 
-        setScheduledInspectionsFromDB(JSON.parse(scheduledInspections))
-        setRecentInspectionsFromDB(JSON.parse(recentInspections))
+        setScheduledInspectionsFromDB(scheduledInspections)
+        setRecentInspectionsFromDB(recentInspections)
     }
 
     useEffect(()=>{


### PR DESCRIPTION
## Summary
- parse API responses once in db helpers
- drop extra JSON.parse calls across components and pages

## Testing
- `npm --prefix client install --silent` *(fails: react-scripts not found)*