### PR TITLE
Add Jest setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # fullstack-boilerplate
 [node + express + mongo] backend api &amp; [react] frontend
+
+## Testing
+
+The API uses [Jest](https://jestjs.io/) with [Supertest](https://github.com/ladjs/supertest)
+for endpoint testing.
+
+From the `api` directory run:
+
+```bash
+npm test
+```
+
+This will execute all tests under `api/test`.

--- a/api/jest.config.js
+++ b/api/jest.config.js
@@ -1,3 +1,5 @@
 module.exports = {
-  testEnvironment: 'node'
+  testEnvironment: 'node',
+  // Load Supertest request helper before running tests
+  setupFilesAfterEnv: ['<rootDir>/test/setup.js']
 };

--- a/api/test/root.test.js
+++ b/api/test/root.test.js
@@ -1,9 +1,9 @@
-const request = require('supertest');
-const app = require('../app');
+// `request` is provided by the Jest setup file
+
 
 describe('GET /', () => {
   it('responds with expected text', async () => {
-    const res = await request(app).get('/');
+    const res = await request.get('/');
     expect(res.statusCode).toBe(200);
     expect(res.text).toBe('Hey! Quit snooping. Go away and mind your own business!');
   });

--- a/api/test/setup.js
+++ b/api/test/setup.js
@@ -1,0 +1,5 @@
+const request = require('supertest');
+const app = require('../app');
+
+// Expose a preconfigured request instance globally
+global.request = request(app);


### PR DESCRIPTION
## Summary
- configure Jest for the API
- add global Supertest helper
- document how to run tests

## Testing
- `npm test` *(fails: jest not found)*