### PR TITLE
Add Supabase backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,12 @@ npm test
 ```
 
 This will execute all tests under `api/test`.
+
+## Environment Variables
+
+The API requires the following variables to connect to Supabase:
+
+```bash
+SUPABASE_URL=<your-supabase-project-url>
+SUPABASE_KEY=<your-service-role-key>
+```

--- a/api/db/dbAssets.js
+++ b/api/db/dbAssets.js
@@ -1,0 +1,36 @@
+const supabase = require('./supabaseClient');
+
+async function createNewClient(data) {
+  const { data: result, error } = await supabase.from('clients').insert(data).select().single();
+  if (error) throw error;
+  return result;
+}
+
+async function createNewInspection(data) {
+  const { data: result, error } = await supabase.from('inspections').insert(data).select().single();
+  if (error) throw error;
+  return result;
+}
+
+async function updateInspection(id, updates) {
+  const { data: result, error } = await supabase
+    .from('inspections')
+    .update(updates)
+    .eq('id', id)
+    .select()
+    .single();
+  if (error) throw error;
+  return result;
+}
+
+async function deleteInspection(id) {
+  const { error } = await supabase.from('inspections').delete().eq('id', id);
+  if (error) throw error;
+}
+
+module.exports = {
+  createNewClient,
+  createNewInspection,
+  updateInspection,
+  deleteInspection
+};

--- a/api/db/supabaseClient.js
+++ b/api/db/supabaseClient.js
@@ -1,0 +1,8 @@
+const { createClient } = require('@supabase/supabase-js');
+
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_KEY;
+
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+module.exports = supabase;

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -905,16 +905,6 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
-    "mongoose-legacy-pluralize": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
-      "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ=="
-    },
-    "mongoose-partial-full-search": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/mongoose-partial-full-search/-/mongoose-partial-full-search-0.0.4.tgz",
-      "integrity": "sha512-lwGofAuX0t194LTmnXWvpHg3fiLcUgIYjNLZ4vXm8QW3uCH/ozBBp0flfwB49gl7dQIi/zOO1xXPGM6B8JqtrQ=="
-    },
     "morgan": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",

--- a/api/package.json
+++ b/api/package.json
@@ -16,7 +16,8 @@
     "express": "~4.16.1",
     "http-errors": "~1.6.3",
     "morgan": "~1.9.1",
-    "nodemon": "^2.0.4"
+    "nodemon": "^2.0.4",
+    "@supabase/supabase-js": "^2.45.4"
   },
   "devDependencies": {
     "jest": "^29.6.2",

--- a/api/routes/index.js
+++ b/api/routes/index.js
@@ -1,9 +1,53 @@
 var express = require('express');
+const {
+  createNewClient,
+  createNewInspection,
+  updateInspection,
+  deleteInspection
+} = require('../db/dbAssets');
 var router = express.Router();
 
 /* GET home page */
 router.get('/', function(req, res, next) {
   res.send('Hey! Quit snooping. Go away and mind your own business!');
+});
+
+// Create a new client
+router.post('/clients', async function(req, res, next) {
+  try {
+    const client = await createNewClient(req.body);
+    res.json(client);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Create a new inspection
+router.post('/inspections', async function(req, res, next) {
+  try {
+    const inspection = await createNewInspection(req.body);
+    res.json(inspection);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.put('/inspections/:id', async function(req, res, next) {
+  try {
+    const inspection = await updateInspection(req.params.id, req.body);
+    res.json(inspection);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.delete('/inspections/:id', async function(req, res, next) {
+  try {
+    await deleteInspection(req.params.id);
+    res.status(204).end();
+  } catch (err) {
+    next(err);
+  }
 });
 
 module.exports = router;

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -816,14 +816,6 @@ minimist@^1.2.0:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz#3ba9f91fa507b5186d399fb40854bff18fb563e4"
-  integrity sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==
-
-mongoose-partial-full-search@^0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/mongoose-partial-full-search/-/mongoose-partial-full-search-0.0.4.tgz#9b57b59df9578b4e0a99da6388c1c56faa362d25"
-  integrity sha512-lwGofAuX0t194LTmnXWvpHg3fiLcUgIYjNLZ4vXm8QW3uCH/ozBBp0flfwB49gl7dQIi/zOO1xXPGM6B8JqtrQ==
 
 morgan@~1.9.1:
   version "1.9.1"


### PR DESCRIPTION
## Summary
- add supabase-js to API deps
- provide Supabase client and helper functions
- wire new endpoints to Supabase
- document SUPABASE_URL and SUPABASE_KEY env vars
- strip old mongoose references from lock files

## Testing
- `npm test` *(fails: jest not found)*