### PR TITLE
Document and configure REACT_APP_API_HOST

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 SUPABASE_URL=<your-supabase-project-url>
 SUPABASE_KEY=<your-supabase-service-key>
-REACT_APP_API_HOST=<your-api-host-url>
+# Hostname and port for the backend API
+# Defaults to localhost:5000 if unset
+REACT_APP_API_HOST=localhost:5000

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The API expects the following variables to be available at runtime:
 SUPABASE_URL=<your-supabase-project-url>
 SUPABASE_KEY=<your-supabase-service-key>
 ```
+The React client reads `REACT_APP_API_HOST` to determine the API host. If omitted, it defaults to `localhost:5000`.
 
 These values are used to initialize the Supabase client in `api/db/supabaseClient.js`.
 

--- a/client/src/db/host.js
+++ b/client/src/db/host.js
@@ -1,7 +1,1 @@
-exports.host = 'localhost:5000'
-
-// pipecam-alpha (client)
-// exports.host = '34.219.201.189:5000'
-
-// pipecam-alpha-api
-// exports.host = '34.220.180.16:5000'
+exports.host = process.env.REACT_APP_API_HOST || 'localhost:5000'


### PR DESCRIPTION
## Summary
- allow overriding API host via `REACT_APP_API_HOST`
- document the environment variable in README
- show API host example in `.env.example`

## Testing
- `npm test` *(fails: jest not found)*