### PR TITLE
Fix syntax error in Observations component

### DIFF
--- a/client/src/components/worksheet_sections/Observations.js
+++ b/client/src/components/worksheet_sections/Observations.js
@@ -1309,4 +1309,5 @@ const ObservationList = (props) => {
         </Modal>
         </>
     )
+    }
 }


### PR DESCRIPTION
## Summary
- fix missing closing brace for if block in Observations.js

## Testing
- `npm test` *(fails: Error: no test specified)*