### PR TITLE
Add setup script

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+
+install_if_needed() {
+  local dir="$1"
+  local name="$2"
+
+  if [ ! -d "$dir/node_modules" ]; then
+    echo "Installing npm dependencies in $name..."
+    (cd "$dir" && npm install)
+  else
+    echo "Dependencies already installed in $name."
+  fi
+}
+
+install_if_needed . "root"
+install_if_needed api "api"
+install_if_needed client "client"
+

--- a/README.md
+++ b/README.md
@@ -14,12 +14,15 @@ The scripts use the `pgcrypto` extension so UUID values can be generated via `ge
 
 ## Development Setup
 
-Install dependencies in both the backend and frontend projects:
+Install dependencies using the setup script:
 
 ```bash
-cd api && npm install
-cd ../client && npm install
+./.codex/setup.sh
 ```
+
+Run this once after cloning the repository. It installs packages in the root,
+`api`, and `client` directories if their `node_modules` folders are missing.
+If the script isn't executable, run `chmod +x .codex/setup.sh` first.
 
 Start the backend server:
 


### PR DESCRIPTION
## Summary
- add `.codex/setup.sh` script to install dependencies if needed
- document usage of the setup script in the README
- clarify README instructions about running the script

## Testing
- `npm test` *(fails: Error: no test specified)*
- `(from api/) npm test` *(fails: jest not found)*